### PR TITLE
Fix bug in `OvenClient.getStabilityFees`

### DIFF
--- a/src/oven-client.ts
+++ b/src/oven-client.ts
@@ -181,7 +181,7 @@ export default class OvenClient {
       .times(totalPrinciple)
       .div(SHARD_PRECISION)
       .integerValue()
-    return newTotalTokens.minus(totalPrinciple)
+    return newTotalTokens.minus(borrowedTokens)
   }
 
   /**


### PR DESCRIPTION
It was reported to us that occasional stability fee calculations were being displayed improperly in the frontend, so we took a look. After investigating we found that there was a subtle bug in the calculations being done in `OvenClient.getStabilityFee` where in some circumstances we'd return the wrong value (displaying less interest accrued than was accurate).

This has to do with how the interest in ovens is calculated (see https://kolibri.finance/project-info/general/intro for an explanation of how things like `Global Interest Index` and an Oven's `Interest Index`), and this bug basically stems from the fact that we're calculating the total tokens owed and subtracting calculated principle (which is basically the interest accrued *since the last time an update happened*) instead of the whole pile of the owed stability fee.

Basically, this manifests that for most ovens things display totally fine (since people tend to borrow once and haven't done much with their ovens since), but if you do something like `borrow()` twice in a row or `borrow()` and a partial `repay()`, we'll only end up displaying the fees accrued since the last call instead of the total accrued fees.

The remedy is to take the total outstanding tokens, and subtract the total accrued interest, instead of only part of it. 