### PR TITLE
Add Florence to Network enum

### DIFF
--- a/src/network.ts
+++ b/src/network.ts
@@ -3,6 +3,7 @@
  */
 enum Network {
   Delphi = 'delphinet',
+  Florence = 'florencenet',
   Mainnet = 'mainnet',
 }
 


### PR DESCRIPTION
I'm working on the kolibri Discord bot and I'm unable to hit the correct endpoint on Better Call using Network.{network} due to it not existing.