### PR TITLE
Misc Updates/v1.8.0

### DIFF
--- a/__tests__/harbinger-client.test.ts
+++ b/__tests__/harbinger-client.test.ts
@@ -16,7 +16,7 @@ jest.setTimeout(30_000) // 30 seconds
 // Client under test
 const harbingerClient = new HarbingerClient(
   NODE_URL,
-  CONTRACTS.DELPHI.HARBINGER_NORMALIZER,
+  CONTRACTS.TEST.HARBINGER_NORMALIZER,
 )
 
 test('harbinger client - gets date', async function () {

--- a/__tests__/oven-client.test.ts
+++ b/__tests__/oven-client.test.ts
@@ -29,9 +29,9 @@ const TEST_ACCOUNT_SECRET =
 const stableCoinClient = new StableCoinClient(
   NODE_URL,
   Network.Delphi,
-  CONTRACTS.DELPHI.OVEN_REGISTRY,
-  CONTRACTS.DELPHI.MINTER,
-  CONTRACTS.DELPHI.OVEN_FACTORY,
+  CONTRACTS.TEST.OVEN_REGISTRY,
+  CONTRACTS.TEST.MINTER,
+  CONTRACTS.TEST.OVEN_FACTORY,
 )
 
 // Time to sleep to let operations settle.
@@ -43,7 +43,7 @@ jest.retryTimes(10)
 // Harbinger Client
 const harbingerClient = new HarbingerClient(
   NODE_URL,
-  CONTRACTS.DELPHI.HARBINGER_NORMALIZER,
+  CONTRACTS.TEST.HARBINGER_NORMALIZER,
 )
 
 test('oven client - can borrow', async function () {

--- a/__tests__/stable-coin-client.test.ts
+++ b/__tests__/stable-coin-client.test.ts
@@ -23,9 +23,9 @@ const TEST_ACCOUNT_SECRET =
 const stableCoinClient = new StableCoinClient(
   NODE_URL,
   Network.Delphi,
-  CONTRACTS.DELPHI.OVEN_REGISTRY,
-  CONTRACTS.DELPHI.MINTER,
-  CONTRACTS.DELPHI.OVEN_FACTORY,
+  CONTRACTS.TEST.OVEN_REGISTRY,
+  CONTRACTS.TEST.MINTER,
+  CONTRACTS.TEST.OVEN_FACTORY,
 )
 
 // Time to sleep to let operations settle.

--- a/__tests__/token-client.test.ts
+++ b/__tests__/token-client.test.ts
@@ -2,7 +2,7 @@ import CONTRACTS from '../src/contracts'
 import TokenClient from '../src/token-client'
 import BigNumber from 'bignumber.js'
 
-const NODE_URL = 'https://rpctest.tzbeta.net'
+const NODE_URL = 'https://testnet-tezos.giganode.io'
 
 /**
  * Tests for Token client.
@@ -17,7 +17,7 @@ const NON_TOKEN_HOLDER_ADDRESS = 'tz1abmz7jiCV2GH2u81LRrGgAFFgvQgiDiaf'
 // const TEST_ACCOUNT_ADDRESS = 'tz1YfB2H1NoZVUq4heHqrVX4oVp99yz8gwNq'
 
 // Token Client under test.
-const tokenClient = new TokenClient(NODE_URL, CONTRACTS.DELPHI.TOKEN)
+const tokenClient = new TokenClient(NODE_URL, CONTRACTS.TEST.TOKEN)
 
 // Allow extra time for RPCs
 jest.setTimeout(30_000) // 30 seconds

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@hover-labs/kolibri-js",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hover-labs/kolibri-js",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@taquito/signer": "^8.0.1-beta.1",
-        "@taquito/taquito": "^8.0.1-beta.1",
+        "@taquito/signer": "^9.1.0",
+        "@taquito/taquito": "^9.1.0",
         "@thanos-wallet/dapp": "^2.2.1",
         "axios": "^0.21.0",
         "bignumber.js": "^9.0.1",
@@ -801,9 +801,9 @@
       }
     },
     "node_modules/@taquito/http-utils": {
-      "version": "8.0.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-8.0.1-beta.1.tgz",
-      "integrity": "sha512-8zIqop+t8s6ti853wAgXNQTec2J8jRtMfa+igIBBlasgn92acaWVBPolJ4dOF6m/89HGBQpzu2vNxCQo1BbFbA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-9.1.0.tgz",
+      "integrity": "sha512-NeTzxAHI4Q0kLT8mt9Ss9JkfeJSfezcg0G8DjLyihqVejHYgCenocUTWARUCBYICg12vrWNj26cVc79ZecXZpA==",
       "dependencies": {
         "xhr2-cookies": "^1.1.0"
       },
@@ -812,20 +812,20 @@
       }
     },
     "node_modules/@taquito/michel-codec": {
-      "version": "8.0.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-8.0.1-beta.1.tgz",
-      "integrity": "sha512-tSEuarwhvEf3HlL8og3n62TMY5u3KwIVO+g47aScLSUi9n/KtBkQqeMWPwQlpThsZfPVu99xUaFV9OR0uA3c+A==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-9.1.0.tgz",
+      "integrity": "sha512-Ijnfnsj2U27diJhbNdecPPyEXKbfCcRwfbzR3vH6oIhYRw9EfBpQR2foX9Yalv3E5OUeNTDCfLVNivuCDgAVHw==",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@taquito/michelson-encoder": {
-      "version": "8.0.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-8.0.1-beta.1.tgz",
-      "integrity": "sha512-543C+Llpr4Xl1ynmHeqB+aiMklhepL3YMA/plfs1V1cHsQQoNrRGKsA5kqVuU9b/Cb6lu/mlUtTw71tvAjTHhQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-9.1.0.tgz",
+      "integrity": "sha512-47NtfJSEpQOwtQcvNIuNuzMeY35ZjeiOp6j7cbgw/hyrXil9aqGI4EB1K+DUM2MUsN+fyN697NrbVPzRaGa/+A==",
       "dependencies": {
-        "@taquito/rpc": "^8.0.1-beta.1",
-        "@taquito/utils": "^8.0.1-beta.1",
+        "@taquito/rpc": "^9.1.0",
+        "@taquito/utils": "^9.1.0",
         "bignumber.js": "^9.0.1",
         "fast-json-stable-stringify": "^2.1.0"
       },
@@ -834,11 +834,11 @@
       }
     },
     "node_modules/@taquito/rpc": {
-      "version": "8.0.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-8.0.1-beta.1.tgz",
-      "integrity": "sha512-msssYDasbseX1s5sZxiGsFcfeGvsOJcATQbzqxvyHZdti2reUs8L1YzsX3LOKx4T8y5s4+qT8LHtZgaB4xwZeg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-9.1.0.tgz",
+      "integrity": "sha512-xlKcis5vYlLo2Htnan4/F5YyYvC2zHbokO8+oH6CeibR8CLZqaj+M4Xea6GeOJYiH+NJG7oUJ1Xclzladia7jQ==",
       "dependencies": {
-        "@taquito/http-utils": "^8.0.1-beta.1",
+        "@taquito/http-utils": "^9.1.0",
         "bignumber.js": "^9.0.1",
         "lodash": "^4.17.20"
       },
@@ -847,15 +847,15 @@
       }
     },
     "node_modules/@taquito/signer": {
-      "version": "8.0.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-8.0.1-beta.1.tgz",
-      "integrity": "sha512-XF0Ljr2OqgUUh4VYEKm8j2MQm4p2sAaxJBpYX2v0/8FA4SiUpbFx46jzW/A8K6czlLWOjngFClsU6Td333ZOxw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-9.1.0.tgz",
+      "integrity": "sha512-fOX45cni2eHvyAhuxuAcISatZ2ZSsvX1jOonrLFvrPnCPEQY058lr2xXwgwkgrQTb8r1goItJ8exkCVfgIhjaA==",
       "dependencies": {
-        "@taquito/taquito": "^8.0.1-beta.1",
-        "@taquito/utils": "^8.0.1-beta.1",
+        "@taquito/taquito": "^9.1.0",
+        "@taquito/utils": "^9.1.0",
         "bignumber.js": "^9.0.1",
         "bip39": "^3.0.2",
-        "elliptic": "^6.5.3",
+        "elliptic": "^6.5.4",
         "libsodium-wrappers": "^0.7.8",
         "pbkdf2": "^3.1.1",
         "typedarray-to-buffer": "^3.1.5"
@@ -865,16 +865,16 @@
       }
     },
     "node_modules/@taquito/taquito": {
-      "version": "8.0.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-8.0.1-beta.1.tgz",
-      "integrity": "sha512-8kmu7EeFbmupRimJ8c/x5+zwFUbZ9loLBp3btH1y1MFx3cBqSLWRvzfGg2GLjzz1+n7iK7JBNx+xjIB6bfJ/FA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-9.1.0.tgz",
+      "integrity": "sha512-O7wzahgsDcqHLACyeaYz2KcQhzPYf1SicKPl/mqTeM5Md3ibGKptLsOxxCKqW8MBr2bbuVZOMyvvzUrjuHPJEQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@taquito/http-utils": "^8.0.1-beta.1",
-        "@taquito/michel-codec": "^8.0.1-beta.1",
-        "@taquito/michelson-encoder": "^8.0.1-beta.1",
-        "@taquito/rpc": "^8.0.1-beta.1",
-        "@taquito/utils": "^8.0.1-beta.1",
+        "@taquito/http-utils": "^9.1.0",
+        "@taquito/michel-codec": "^9.1.0",
+        "@taquito/michelson-encoder": "^9.1.0",
+        "@taquito/rpc": "^9.1.0",
+        "@taquito/utils": "^9.1.0",
         "bignumber.js": "^9.0.1",
         "rx-sandbox": "^1.0.3",
         "rxjs": "^6.6.3"
@@ -884,9 +884,9 @@
       }
     },
     "node_modules/@taquito/utils": {
-      "version": "8.0.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-8.0.1-beta.1.tgz",
-      "integrity": "sha512-vOdlWNwTUNusYg0vACpn1xrU3Vtlnq/E6IBmdoq1+ctzxAJryqwrLpEOO1Xag8Dpf7qqUWLPSrrFO4t9uuvQXw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-9.1.0.tgz",
+      "integrity": "sha512-W9FMvsKU8beaCFhj+3Xoxoy0P05x+YjFqApdmYgsBp4YCRmmrPAhqi4AJ7wdRYl++v25FplZNPcUW/k3QgdQJw==",
       "dependencies": {
         "blakejs": "^1.1.0",
         "bs58check": "^2.1.2",
@@ -3652,9 +3652,9 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -6460,9 +6460,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
-      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -7966,12 +7966,24 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xhr2-cookies": {
@@ -8736,73 +8748,73 @@
       }
     },
     "@taquito/http-utils": {
-      "version": "8.0.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-8.0.1-beta.1.tgz",
-      "integrity": "sha512-8zIqop+t8s6ti853wAgXNQTec2J8jRtMfa+igIBBlasgn92acaWVBPolJ4dOF6m/89HGBQpzu2vNxCQo1BbFbA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-9.1.0.tgz",
+      "integrity": "sha512-NeTzxAHI4Q0kLT8mt9Ss9JkfeJSfezcg0G8DjLyihqVejHYgCenocUTWARUCBYICg12vrWNj26cVc79ZecXZpA==",
       "requires": {
         "xhr2-cookies": "^1.1.0"
       }
     },
     "@taquito/michel-codec": {
-      "version": "8.0.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-8.0.1-beta.1.tgz",
-      "integrity": "sha512-tSEuarwhvEf3HlL8og3n62TMY5u3KwIVO+g47aScLSUi9n/KtBkQqeMWPwQlpThsZfPVu99xUaFV9OR0uA3c+A=="
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-9.1.0.tgz",
+      "integrity": "sha512-Ijnfnsj2U27diJhbNdecPPyEXKbfCcRwfbzR3vH6oIhYRw9EfBpQR2foX9Yalv3E5OUeNTDCfLVNivuCDgAVHw=="
     },
     "@taquito/michelson-encoder": {
-      "version": "8.0.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-8.0.1-beta.1.tgz",
-      "integrity": "sha512-543C+Llpr4Xl1ynmHeqB+aiMklhepL3YMA/plfs1V1cHsQQoNrRGKsA5kqVuU9b/Cb6lu/mlUtTw71tvAjTHhQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-9.1.0.tgz",
+      "integrity": "sha512-47NtfJSEpQOwtQcvNIuNuzMeY35ZjeiOp6j7cbgw/hyrXil9aqGI4EB1K+DUM2MUsN+fyN697NrbVPzRaGa/+A==",
       "requires": {
-        "@taquito/rpc": "^8.0.1-beta.1",
-        "@taquito/utils": "^8.0.1-beta.1",
+        "@taquito/rpc": "^9.1.0",
+        "@taquito/utils": "^9.1.0",
         "bignumber.js": "^9.0.1",
         "fast-json-stable-stringify": "^2.1.0"
       }
     },
     "@taquito/rpc": {
-      "version": "8.0.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-8.0.1-beta.1.tgz",
-      "integrity": "sha512-msssYDasbseX1s5sZxiGsFcfeGvsOJcATQbzqxvyHZdti2reUs8L1YzsX3LOKx4T8y5s4+qT8LHtZgaB4xwZeg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-9.1.0.tgz",
+      "integrity": "sha512-xlKcis5vYlLo2Htnan4/F5YyYvC2zHbokO8+oH6CeibR8CLZqaj+M4Xea6GeOJYiH+NJG7oUJ1Xclzladia7jQ==",
       "requires": {
-        "@taquito/http-utils": "^8.0.1-beta.1",
+        "@taquito/http-utils": "^9.1.0",
         "bignumber.js": "^9.0.1",
         "lodash": "^4.17.20"
       }
     },
     "@taquito/signer": {
-      "version": "8.0.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-8.0.1-beta.1.tgz",
-      "integrity": "sha512-XF0Ljr2OqgUUh4VYEKm8j2MQm4p2sAaxJBpYX2v0/8FA4SiUpbFx46jzW/A8K6czlLWOjngFClsU6Td333ZOxw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-9.1.0.tgz",
+      "integrity": "sha512-fOX45cni2eHvyAhuxuAcISatZ2ZSsvX1jOonrLFvrPnCPEQY058lr2xXwgwkgrQTb8r1goItJ8exkCVfgIhjaA==",
       "requires": {
-        "@taquito/taquito": "^8.0.1-beta.1",
-        "@taquito/utils": "^8.0.1-beta.1",
+        "@taquito/taquito": "^9.1.0",
+        "@taquito/utils": "^9.1.0",
         "bignumber.js": "^9.0.1",
         "bip39": "^3.0.2",
-        "elliptic": "^6.5.3",
+        "elliptic": "^6.5.4",
         "libsodium-wrappers": "^0.7.8",
         "pbkdf2": "^3.1.1",
         "typedarray-to-buffer": "^3.1.5"
       }
     },
     "@taquito/taquito": {
-      "version": "8.0.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-8.0.1-beta.1.tgz",
-      "integrity": "sha512-8kmu7EeFbmupRimJ8c/x5+zwFUbZ9loLBp3btH1y1MFx3cBqSLWRvzfGg2GLjzz1+n7iK7JBNx+xjIB6bfJ/FA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-9.1.0.tgz",
+      "integrity": "sha512-O7wzahgsDcqHLACyeaYz2KcQhzPYf1SicKPl/mqTeM5Md3ibGKptLsOxxCKqW8MBr2bbuVZOMyvvzUrjuHPJEQ==",
       "requires": {
-        "@taquito/http-utils": "^8.0.1-beta.1",
-        "@taquito/michel-codec": "^8.0.1-beta.1",
-        "@taquito/michelson-encoder": "^8.0.1-beta.1",
-        "@taquito/rpc": "^8.0.1-beta.1",
-        "@taquito/utils": "^8.0.1-beta.1",
+        "@taquito/http-utils": "^9.1.0",
+        "@taquito/michel-codec": "^9.1.0",
+        "@taquito/michelson-encoder": "^9.1.0",
+        "@taquito/rpc": "^9.1.0",
+        "@taquito/utils": "^9.1.0",
         "bignumber.js": "^9.0.1",
         "rx-sandbox": "^1.0.3",
         "rxjs": "^6.6.3"
       }
     },
     "@taquito/utils": {
-      "version": "8.0.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-8.0.1-beta.1.tgz",
-      "integrity": "sha512-vOdlWNwTUNusYg0vACpn1xrU3Vtlnq/E6IBmdoq1+ctzxAJryqwrLpEOO1Xag8Dpf7qqUWLPSrrFO4t9uuvQXw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-9.1.0.tgz",
+      "integrity": "sha512-W9FMvsKU8beaCFhj+3Xoxoy0P05x+YjFqApdmYgsBp4YCRmmrPAhqi4AJ7wdRYl++v25FplZNPcUW/k3QgdQJw==",
       "requires": {
         "blakejs": "^1.1.0",
         "bs58check": "^2.1.2",
@@ -11056,9 +11068,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -13275,9 +13287,9 @@
       }
     },
     "rxjs": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
-      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -14513,10 +14525,11 @@
       }
     },
     "ws": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
-      "dev": true
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "dev": true,
+      "requires": {}
     },
     "xhr2-cookies": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hover-labs/kolibri-js",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "SDK Code to Interact with Kolbri, a stablecoin built on Tezos",
   "main": "build/src/index.js",
   "files": [
@@ -39,8 +39,8 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
-    "@taquito/signer": "^8.0.1-beta.1",
-    "@taquito/taquito": "^8.0.1-beta.1",
+    "@taquito/signer": "^9.1.0",
+    "@taquito/taquito": "^9.1.0",
     "@thanos-wallet/dapp": "^2.2.1",
     "axios": "^0.21.0",
     "bignumber.js": "^9.0.1",

--- a/src/network.ts
+++ b/src/network.ts
@@ -2,9 +2,12 @@
  * Networks to operate on.
  */
 enum Network {
-  Delphi = 'delphinet',
-  Florence = 'florencenet',
   Mainnet = 'mainnet',
+  Delphi = 'delphinet',
+  Edo2Net = 'edo2net',
+  Florence = 'florencenet',
+  Granada = 'granadanet',
+  Sandbox = 'sandboxnet',
 }
 
 export default Network


### PR DESCRIPTION
This PR brings in a few changes:
- Fixes tests
- Bumps taquito to v9.1.0 (and runs npm audit fix)
- Expands networks to include Edo, Granada, and Sandbox networks
- Fits `StableCoinClient.getAllOvens` to default to current behavior, but optionally specify an IndexerURL to point things to a better-call.dev API and paginate from there instead of the s3 cache. 