### PR TITLE
[1.12.0] Rework DEX Data in Contracts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hover-labs/kolibri-js",
-  "version": "1.8.0",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hover-labs/kolibri-js",
-      "version": "1.8.0",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
         "@taquito/signer": "^9.1.0",
@@ -647,7 +647,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -4671,7 +4670,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hover-labs/kolibri-js",
-  "version": "1.11.2",
+  "version": "1.12.0",
   "description": "SDK Code to Interact with Kolbri, a stablecoin built on Tezos",
   "main": "build/src/index.js",
   "files": [

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -23,12 +23,12 @@ const CONTRACTS: Contracts = {
     // Kolibri Liqiudity Pool
     LIQUIDITY_POOL: null,
 
-    // Dex Configurations
+    // DEX Configurations
     DEXES: {
       QUIPUSWAP: {
-        QUIPUSWAP_POOL: null,
-        QUIPUSWAP_FA1_2_FACTORY: null,
-        QUIPUSWAP_FA2_FACTORY: null,
+        POOL: null,
+        FA1_2_FACTORY: null,
+        FA2_FACTORY: null,
       }
     }
 
@@ -68,12 +68,12 @@ const CONTRACTS: Contracts = {
     // Kolibri Liquidity Pool
     LIQUIDITY_POOL: 'KT19RUbUUizsy7arXiziEi9d2nfJNMG74KxS',
 
-    // Dex Configurations
+    // DEX Configurations
     DEXES: {
       QUIPUSWAP: {
-        QUIPUSWAP_POOL: "KT1XcRsVNqvwRNyfoqZaKenPT2mQdLd2d8fS",
-        QUIPUSWAP_FA1_2_FACTORY: 'KT195gyo5G7pay2tYweWDeYFkGLqcvQTXoCW',
-        QUIPUSWAP_FA2_FACTORY: 'KT1HjLwPC3sbh6W5HjaKBsiVPTgptcNbnXnc',
+        POOL: "KT1XcRsVNqvwRNyfoqZaKenPT2mQdLd2d8fS",
+        FA1_2_FACTORY: 'KT195gyo5G7pay2tYweWDeYFkGLqcvQTXoCW',
+        FA2_FACTORY: 'KT1HjLwPC3sbh6W5HjaKBsiVPTgptcNbnXnc',
       }
     },
 
@@ -126,12 +126,11 @@ const CONTRACTS: Contracts = {
     LIQUIDITY_POOL: 'KT1AxaBxkFLCUi3f8rdDAAxBKHfzY8LfKDRA',
 
     // DEX Configurations
-    // Dex Configurations
     DEXES: {
       QUIPUSWAP: {
-        QUIPUSWAP_POOL: "KT1K4EwTpbvYN9agJdjpyJm4ZZdhpUNKB3F6",
-        QUIPUSWAP_FA1_2_FACTORY: 'KT1Lw8hCoaBrHeTeMXbqHPG4sS4K1xn7yKcD',
-        QUIPUSWAP_FA2_FACTORY: 'KT1SwH9P1Tx8a58Mm6qBExQFTcy2rwZyZiXS',
+        POOL: "KT1K4EwTpbvYN9agJdjpyJm4ZZdhpUNKB3F6",
+        FA1_2_FACTORY: 'KT1Lw8hCoaBrHeTeMXbqHPG4sS4K1xn7yKcD',
+        FA2_FACTORY: 'KT1SwH9P1Tx8a58Mm6qBExQFTcy2rwZyZiXS',
       }
     },
 

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -23,9 +23,14 @@ const CONTRACTS: Contracts = {
     // Kolibri Liqiudity Pool
     LIQUIDITY_POOL: null,
 
-    // DEX Liquidity Pools
-    DEXTER_POOL: null,
-    QUIPUSWAP_POOL: null,
+    // Dex Configurations
+    DEXES: {
+      QUIPUSWAP: {
+        QUIPUSWAP_POOL: null,
+        QUIPUSWAP_FA1_2_FACTORY: null,
+        QUIPUSWAP_FA2_FACTORY: null,
+      }
+    }
 
     // Below values are not applicable to testnet deployment.
     KOLIBRI_BAKER: null,
@@ -63,9 +68,14 @@ const CONTRACTS: Contracts = {
     // Kolibri Liquidity Pool
     LIQUIDITY_POOL: 'KT19RUbUUizsy7arXiziEi9d2nfJNMG74KxS',
 
-    // DEX Liquidity Pools
-    DEXTER_POOL: null,
-    QUIPUSWAP_POOL: 'KT1XcRsVNqvwRNyfoqZaKenPT2mQdLd2d8fS',
+    // Dex Configurations
+    DEXES: {
+      QUIPUSWAP: {
+        QUIPUSWAP_POOL: "KT1XcRsVNqvwRNyfoqZaKenPT2mQdLd2d8fS",
+        QUIPUSWAP_FA1_2_FACTORY: 'KT195gyo5G7pay2tYweWDeYFkGLqcvQTXoCW',
+        QUIPUSWAP_FA2_FACTORY: 'KT1HjLwPC3sbh6W5HjaKBsiVPTgptcNbnXnc',
+      }
+    },
 
     // Below values are not applicable to testnet deployment.
     KOLIBRI_BAKER: 'tz1burnburnburnburnburnburnburjAYjjX',
@@ -115,9 +125,15 @@ const CONTRACTS: Contracts = {
     // Kolibri Liqiudity Pool
     LIQUIDITY_POOL: 'KT1AxaBxkFLCUi3f8rdDAAxBKHfzY8LfKDRA',
 
-    // DEX Liquidity Pools
-    DEXTER_POOL: 'KT1AbYeDbjjcAnV1QK7EZUUdqku77CdkTuv6',
-    QUIPUSWAP_POOL: 'KT1K4EwTpbvYN9agJdjpyJm4ZZdhpUNKB3F6',
+    // DEX Configurations
+    // Dex Configurations
+    DEXES: {
+      QUIPUSWAP: {
+        QUIPUSWAP_POOL: "KT1K4EwTpbvYN9agJdjpyJm4ZZdhpUNKB3F6",
+        QUIPUSWAP_FA1_2_FACTORY: 'KT1Lw8hCoaBrHeTeMXbqHPG4sS4K1xn7yKcD',
+        QUIPUSWAP_FA2_FACTORY: 'KT1SwH9P1Tx8a58Mm6qBExQFTcy2rwZyZiXS',
+      }
+    },
 
     // Governance Roles
     GOVERNOR: 'KT1JBmbYxTv3xptk2CadgEdMfjUCUXKEfe5u',

--- a/src/types/contracts.ts
+++ b/src/types/contracts.ts
@@ -19,15 +19,11 @@ export type ContractGroup = {
   // DEX Configurations
   DEXES: {
     QUIPUSWAP: {
-      QUIPUSWAP_POOL: DeployedContractAddressOrNull
-      QUIPUSWAP_FA1_2_FACTORY: DeployedContractAddressOrNull
-      QUIPUSWAP_FA2_FACTORY: DeployedContractAddressOrNull
+      POOL: DeployedContractAddressOrNull
+      FA1_2_FACTORY: DeployedContractAddressOrNull
+      FA2_FACTORY: DeployedContractAddressOrNull
     }
   }
-
-  QUIPUSWAP_POOL: DeployedContractAddressOrNull
-  QUIPUSWAP_FA1_2_FACTORY: DeployedContractAddressOrNull
-  QUIPUSWAP_FA2_FACTORY: DeployedContractAddressOrNull
 
   // Below values are not applicable to testnet deployment.
   KOLIBRI_BAKER: DeployedContractAddressOrNull

--- a/src/types/contracts.ts
+++ b/src/types/contracts.ts
@@ -16,9 +16,18 @@ export type ContractGroup = {
   // Kolibri Liqiudity Pool
   LIQUIDITY_POOL: DeployedContractAddressOrNull
 
-  // DEX Liquidity Pools
-  DEXTER_POOL: DeployedContractAddressOrNull
+  // DEX Configurations
+  DEXES: {
+    QUIPUSWAP: {
+      QUIPUSWAP_POOL: DeployedContractAddressOrNull
+      QUIPUSWAP_FA1_2_FACTORY: DeployedContractAddressOrNull
+      QUIPUSWAP_FA2_FACTORY: DeployedContractAddressOrNull
+    }
+  }
+
   QUIPUSWAP_POOL: DeployedContractAddressOrNull
+  QUIPUSWAP_FA1_2_FACTORY: DeployedContractAddressOrNull
+  QUIPUSWAP_FA2_FACTORY: DeployedContractAddressOrNull
 
   // Below values are not applicable to testnet deployment.
   KOLIBRI_BAKER: DeployedContractAddressOrNull


### PR DESCRIPTION
- Remove Dexter pool (Dexter is dead; liquidity pool is empty)
- Add data on Quipuswap Factories (Useful if you want to use Quipuswap SDK) 
- Rework DEX data into an object so that we can support new DEXes (SpicySwap, PlentySwap, etc)