### PR TITLE
Add more functionality to SavingsPoolClient

### DIFF
--- a/__tests__/harbinger-client.test.ts
+++ b/__tests__/harbinger-client.test.ts
@@ -8,13 +8,13 @@ import BigNumber from 'bignumber.js'
  * These tests are not hermetic.
  */
 
-const NODE_URL = 'https://rpctest.tzbeta.net'
+const NODE_URL = 'https://sandbox.hover.engineering'
 
 // Allow extra time for RPCs
 jest.setTimeout(30_000) // 30 seconds
 
 // Client under test
-const harbingerClient = new HarbingerClient(NODE_URL, CONTRACTS.TEST.HARBINGER_NORMALIZER!)
+const harbingerClient = new HarbingerClient(NODE_URL, CONTRACTS.SANDBOX.HARBINGER_NORMALIZER!)
 
 test('harbinger client - gets date', async function () {
   // GIVEN a Harbinger Client

--- a/__tests__/oven-client.test.ts
+++ b/__tests__/oven-client.test.ts
@@ -16,21 +16,24 @@ import CONTRACTS from '../src/contracts'
 // Allow extra time for RPCs
 jest.setTimeout(60_000 * 10) // 10 minutes
 
-const NODE_URL = 'https://rpctest.tzbeta.net'
+const NODE_URL = 'https://sandbox.hover.engineering'
 
 // Adress of an oven.
-const OVEN_ADDRESS = 'KT1SXhvMjA4RVEjWuLyrsYgt1TU3xfeLUDEb'
+const OVEN_ADDRESS = 'KT1K72GzxKkYyv4czu8VqWDETBdJQeJsZEvZ'
 
 // Secret for a test account.
-const TEST_ACCOUNT_SECRET = 'edsk3aeocSRnxdWVFm3ShaALUeCTy4PgL6JdeGvzbLjX5jn8D9ZXw5'
+const TEST_ACCOUNT_SECRET = 'edsk3QoqBuvdamxouPhin7swCvkQNgq4jP5KZPbwWNnwdZpSpJiEbq'
+
+// Contracts
+const CONTRACT_GROUP = CONTRACTS.SANDBOX
 
 // A StableCoinClient
 const stableCoinClient = new StableCoinClient(
   NODE_URL,
-  Network.Delphi,
-  CONTRACTS.TEST.OVEN_REGISTRY!,
-  CONTRACTS.TEST.MINTER!,
-  CONTRACTS.TEST.OVEN_FACTORY!,
+  Network.Sandbox,
+  CONTRACT_GROUP.OVEN_REGISTRY!,
+  CONTRACT_GROUP.MINTER!,
+  CONTRACT_GROUP.OVEN_FACTORY!,
 )
 
 // Time to sleep to let operations settle.
@@ -40,7 +43,7 @@ const SLEEP_TIME = 120
 jest.retryTimes(10)
 
 // Harbinger Client
-const harbingerClient = new HarbingerClient(NODE_URL, CONTRACTS.TEST.HARBINGER_NORMALIZER!)
+const harbingerClient = new HarbingerClient(NODE_URL, CONTRACT_GROUP.HARBINGER_NORMALIZER!)
 
 test('oven client - can borrow', async function () {
   // Let any pending transactions settle

--- a/__tests__/stable-coin-client.test.ts
+++ b/__tests__/stable-coin-client.test.ts
@@ -11,20 +11,22 @@ import BigNumber from 'bignumber.js'
  * These tests are not hermetic.
  */
 
-const NODE_URL = 'https://rpctest.tzbeta.net'
+const NODE_URL = 'https://sandbox.hover.engineering'
 
 // A test account
-// TODO(keefertaylor): Refactor these constants to helpers.
-const TEST_ACCOUNT_ADDRESS = 'tz1YfB2H1NoZVUq4heHqrVX4oVp99yz8gwNq'
-const TEST_ACCOUNT_SECRET = 'edsk3aeocSRnxdWVFm3ShaALUeCTy4PgL6JdeGvzbLjX5jn8D9ZXw5'
+const TEST_ACCOUNT_ADDRESS = 'tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb'
+const TEST_ACCOUNT_SECRET = 'edsk3QoqBuvdamxouPhin7swCvkQNgq4jP5KZPbwWNnwdZpSpJiEbq'
+
+// Contracts
+const CONTRACT_GROUP = CONTRACTS.SANDBOX
 
 // Token Client under test.
 const stableCoinClient = new StableCoinClient(
   NODE_URL,
-  Network.Delphi,
-  CONTRACTS.TEST.OVEN_REGISTRY!,
-  CONTRACTS.TEST.MINTER!,
-  CONTRACTS.TEST.OVEN_FACTORY!,
+  Network.Sandbox,
+  CONTRACT_GROUP.OVEN_REGISTRY!,
+  CONTRACT_GROUP.MINTER!,
+  CONTRACT_GROUP.OVEN_FACTORY!,
 )
 
 // Time to sleep to let operations settle.

--- a/__tests__/token-client.test.ts
+++ b/__tests__/token-client.test.ts
@@ -2,7 +2,7 @@ import CONTRACTS from '../src/contracts'
 import TokenClient from '../src/token-client'
 import BigNumber from 'bignumber.js'
 
-const NODE_URL = 'https://testnet-tezos.giganode.io'
+const NODE_URL = 'https://sandbox.hover.engineering'
 
 /**
  * Tests for Token client.
@@ -16,8 +16,11 @@ const NON_TOKEN_HOLDER_ADDRESS = 'tz1abmz7jiCV2GH2u81LRrGgAFFgvQgiDiaf'
 // An address which should have some tokens.
 // const TEST_ACCOUNT_ADDRESS = 'tz1YfB2H1NoZVUq4heHqrVX4oVp99yz8gwNq'
 
+// Contracts
+const CONTRACT_GROUP = CONTRACTS.SANDBOX
+
 // Token Client under test.
-const tokenClient = new TokenClient(NODE_URL, CONTRACTS.TEST.TOKEN!)
+const tokenClient = new TokenClient(NODE_URL, CONTRACT_GROUP.TOKEN!)
 
 // Allow extra time for RPCs
 jest.setTimeout(30_000) // 30 seconds

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hover-labs/kolibri-js",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hover-labs/kolibri-js",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@taquito/signer": "^10.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hover-labs/kolibri-js",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "SDK Code to Interact with Kolibri, a stablecoin built on Tezos",
   "main": "build/src/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hover-labs/kolibri-js",
   "version": "2.0.1",
-  "description": "SDK Code to Interact with Kolbri, a stablecoin built on Tezos",
+  "description": "SDK Code to Interact with Kolibri, a stablecoin built on Tezos",
   "main": "build/src/index.js",
   "files": [
     "build/**/*",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,17 @@
+import BigNumber from 'bignumber.js'
+
+/** The number of seconds in a compound interest period */
+const COMPOUND_PERIOD_SECONDS = 60
+
+/** Constants used across Kolibri-JS */
+const CONSTANTS = {
+  COMPOUND_PERIOD_SECONDS,
+
+  /** The number of periods that occur per year. */
+  COMPOUNDS_PER_YEAR: (365 * 24 * 60 * 60) / COMPOUND_PERIOD_SECONDS, // (Number of seconds in year) / (seconds per compound)
+
+  /** The number of decimals in smart contract precision */
+  PRECISION: new BigNumber(Math.pow(10, 18))
+}
+
+export default CONSTANTS

--- a/src/savings-pool-client.ts
+++ b/src/savings-pool-client.ts
@@ -2,8 +2,9 @@ import { TezosToolkit, TransactionWalletOperation } from '@taquito/taquito'
 import { InMemorySigner } from '@taquito/signer'
 import { TransactionOperation } from '@taquito/taquito/dist/types/operations/transaction-operation'
 import BigNumber from 'bignumber.js'
-import { compoundingLinearApproximation, interestRateToApy } from './utils'
+import { compoundingLinearApproximation, getTokenBalance, interestRateToApy } from './utils'
 import CONSTANTS from './constants'
+import Address from './types/address'
 
 /**
  * Controls interaction with the Kolibri Savings Pool.
@@ -119,4 +120,10 @@ export default class SavingsPoolClient {
     return poolSize.times(CONSTANTS.PRECISION).times(CONSTANTS.PRECISION).dividedBy(totalLPTokens)
   }
 
+  /** 
+   * Get the LP token balance for the given account.
+   */
+  public async getLPTokenBalance(address: Address): Promise<BigNumber> {
+    return getTokenBalance(address, this.savingsPoolAddress, this.tezos)
+  }
 }

--- a/src/savings-pool-client.ts
+++ b/src/savings-pool-client.ts
@@ -107,4 +107,16 @@ export default class SavingsPoolClient {
     return savingsPoolStorage.totalSupply
   }
 
+  /**
+   * Get the conversion rate of 1 LP token to kUSD, denominated in kUSD.
+   */
+  public async getLPTokenConversionRate(): Promise<BigNumber> {
+    const poolSize = await this.getPoolSize()
+    const totalLPTokens = await this.getLPTokenTotal()
+
+    // NOTE: KSR LP tokens are denominated in 36 digits, and kUSD uses 18 so we upscale the kUSD size to be 
+    //       the same precision.
+    return poolSize.times(CONSTANTS.PRECISION).times(CONSTANTS.PRECISION).dividedBy(totalLPTokens)
+  }
+
 }

--- a/src/savings-pool-client.ts
+++ b/src/savings-pool-client.ts
@@ -40,13 +40,6 @@ export default class SavingsPoolClient {
   }
 
   /**
-   * Wishlist of features:
-   * - Get addresses's balance of kUSD in the pool
-   * - Get pool interest rate
-   * - Get conversion rate of LP Token to kUSD
-   */
-
-  /**
    * Deposit kUSD into the liquidity pool and receive LP tokens.
    * 
    * @param kUSDAmount The amount of kUSD to deposit.
@@ -125,5 +118,17 @@ export default class SavingsPoolClient {
    */
   public async getLPTokenBalance(address: Address): Promise<BigNumber> {
     return getTokenBalance(address, this.savingsPoolAddress, this.tezos)
+  }
+
+  /**
+   * Get the kUSD balance for a given account, if they turned in all of their LP tokens.
+   */
+  public async getkUSDTokenBalance(address: Address): Promise<BigNumber> {
+    const conversionRate = await this.getLPTokenConversionRate()
+    const lpTokenBalance = await this.getLPTokenBalance(address)
+
+    // NOTE: KSR LP tokens are denominated in 36 digits, and kUSD uses 18 so we upscale the kUSD size to be 
+    //       the same precision.
+    return conversionRate.times(lpTokenBalance).dividedBy(CONSTANTS.PRECISION)
   }
 }

--- a/src/savings-pool-client.ts
+++ b/src/savings-pool-client.ts
@@ -98,4 +98,13 @@ export default class SavingsPoolClient {
     return compoundingLinearApproximation(poolSize, interestRate, numPeriods)
   }
 
+  /**
+   * Get the number of LP tokens in existence.
+   */
+  public async getLPTokenTotal(): Promise<BigNumber> {
+    const savingsPoolContract = await this.tezos.wallet.at(this.savingsPoolAddress)
+    const savingsPoolStorage: any = await savingsPoolContract.storage()
+    return savingsPoolStorage.totalSupply
+  }
+
 }

--- a/src/savings-pool-client.ts
+++ b/src/savings-pool-client.ts
@@ -80,12 +80,13 @@ export default class SavingsPoolClient {
     const savingsPoolContract = await this.tezos.wallet.at(this.savingsPoolAddress)
     const savingsPoolStorage: any = await savingsPoolContract.storage()
     const poolSize = savingsPoolStorage.underlyingBalance
-    const lastInterestUpdate = savingsPoolStorage.lastInterestCompoundTime
+    const lastInterestUpdateTime = savingsPoolStorage.lastInterestCompoundTime
     const interestRate = savingsPoolStorage.interestRate
 
     // TODO(keefertaylor): Similiar to the API in StableCoin client. Consider deduping / refactoring.
     const time = new Date()
-    const deltaMs = time.getTime() - lastInterestUpdate.getTime()
+    const lastUpdate = new Date(`${lastInterestUpdateTime}`)
+    const deltaMs = time.getTime() - lastUpdate.getTime()
     const deltaSecs = Math.floor(deltaMs / 1000)
     const numPeriods = Math.floor(deltaSecs / CONSTANTS.COMPOUND_PERIOD_SECONDS)
 

--- a/src/savings-pool-client.ts
+++ b/src/savings-pool-client.ts
@@ -1,7 +1,8 @@
 import { TezosToolkit, TransactionWalletOperation } from '@taquito/taquito'
 import { InMemorySigner } from '@taquito/signer'
 import { TransactionOperation } from '@taquito/taquito/dist/types/operations/transaction-operation'
-import BigNumber from 'bignumber.js';
+import BigNumber from 'bignumber.js'
+import { interestRateToApy } from './utils'
 
 /**
  * Controls interaction with the Kolibri Savings Pool.
@@ -50,9 +51,9 @@ export default class SavingsPoolClient {
    * @returns The operation hash
    */
   public async deposit(kUSDAmount: BigNumber): Promise<TransactionOperation | TransactionWalletOperation> {
-    const liquidityPoolContract = await this.tezos.wallet.at(this.savingsPoolAddress)
+    const savingsPoolContract = await this.tezos.wallet.at(this.savingsPoolAddress)
     const sendArgs = { amount: 0, mutez: true }
-    return await liquidityPoolContract.methods['deposit'](kUSDAmount).send(sendArgs)
+    return await savingsPoolContract.methods['deposit'](kUSDAmount).send(sendArgs)
   }
 
   /**
@@ -62,8 +63,19 @@ export default class SavingsPoolClient {
    * @returns The operation hash
    */
   public async redeem(lpTokenAmount: BigNumber): Promise<TransactionOperation | TransactionWalletOperation> {
-    const liquidityPoolContract = await this.tezos.wallet.at(this.savingsPoolAddress)
+    const savingsPoolContract = await this.tezos.wallet.at(this.savingsPoolAddress)
     const sendArgs = { amount: 0, mutez: true }
-    return await liquidityPoolContract.methods['redeem'](lpTokenAmount).send(sendArgs)
+    return await savingsPoolContract.methods['redeem'](lpTokenAmount).send(sendArgs)
   }
+
+  /**
+   * Get the interest rate of the pool.
+   */
+  public async getInterestRate(): Promise<BigNumber> {
+    const savingsPoolContract = await this.tezos.wallet.at(this.savingsPoolAddress)
+    const savingsPoolStorage: any = await savingsPoolContract.storage()
+    const interestRate = savingsPoolStorage.interestRate
+    return interestRateToApy(interestRate)
+  }
+
 }

--- a/src/stable-coin-client.ts
+++ b/src/stable-coin-client.ts
@@ -9,7 +9,7 @@ import { TransactionOperation } from '@taquito/taquito/dist/types/operations/tra
 import BigNumber from 'bignumber.js'
 import axios, { AxiosResponse } from 'axios'
 import CONSTANTS from './constants'
-import { interestRateToApy } from './utils'
+import { compoundingLinearApproximation, interestRateToApy } from './utils'
 
 /** The result of deploying an Oven. */
 export type OvenDeployResult = {
@@ -161,9 +161,11 @@ export default class StableCoinClient {
 
     const simpleStabilityFee = await this.getSimpleStabilityFee()
 
-    const globalInterestIndexApproximation = globalInterestIndex
-      .times(CONSTANTS.PRECISION.plus(simpleStabilityFee.times(numPeriods)))
-      .div(CONSTANTS.PRECISION)
+    const globalInterestIndexApproximation = compoundingLinearApproximation(
+      globalInterestIndex,
+      simpleStabilityFee,
+      numPeriods
+    )
     return {
       globalInterestIndex: globalInterestIndexApproximation,
       lastUpdateTime: time,

--- a/src/token-client.ts
+++ b/src/token-client.ts
@@ -2,6 +2,7 @@ import { TezosToolkit } from '@taquito/taquito'
 import Shard from './types/shard'
 import Address from './types/address'
 import BigNumber from 'bignumber.js'
+import { getTokenBalance } from './utils'
 
 /** Interacts with the Untitled Stable Coin project's token. */
 export default class TokenClient {
@@ -23,9 +24,6 @@ export default class TokenClient {
    * @returns The token balance.
    */
   public async getBalance(address: Address): Promise<Shard> {
-    const tokenContract = await this.tezos.contract.at(this.tokenAddress)
-    const tokenStorage: any = await tokenContract.storage()
-    const balance = await tokenStorage.balances.get(address)
-    return balance === undefined ? new BigNumber(0) : balance.balance
+    return getTokenBalance(address, this.tokenAddress, this.tezos)
   }
 }

--- a/src/token-client.ts
+++ b/src/token-client.ts
@@ -1,8 +1,11 @@
-import { TezosToolkit } from '@taquito/taquito'
 import Shard from './types/shard'
 import Address from './types/address'
 import BigNumber from 'bignumber.js'
 import { getTokenBalance } from './utils'
+import { TezosToolkit, TransactionWalletOperation } from '@taquito/taquito'
+import { TransactionOperation } from '@taquito/taquito/dist/types/operations/transaction-operation'
+import { TempleWallet } from "@temple-wallet/dapp";
+import { InMemorySigner } from '@taquito/signer'
 
 /** Interacts with the Untitled Stable Coin project's token. */
 export default class TokenClient {
@@ -17,6 +20,31 @@ export default class TokenClient {
   public constructor(nodeUrl: string, private readonly tokenAddress: Address) {
     this.tezos = new TezosToolkit(nodeUrl)
   }
+
+  /**
+   * Approve an allowance for an FA1.2 token
+   * 
+   * @param spender The account who can spend
+   * @param amount The amount to spend
+   * @param wallet The wallet that will approve
+   */
+  public async approveToken(
+    spender: string,
+    amount: BigNumber,
+    wallet: InMemorySigner | TempleWallet,
+  ): Promise<TransactionWalletOperation | TransactionOperation> {
+    if (wallet instanceof InMemorySigner) {
+      // Wallet is InMemorySigner
+      this.tezos.setProvider({ signer: wallet })
+    } else {
+      // Wallet is Temple Wallet
+      this.tezos.setWalletProvider(wallet)
+    }
+
+    const tokenContract = await this.tezos.contract.at(this.tokenAddress)
+    return tokenContract.methods.approve(spender, amount).send()
+  }
+
 
   /**
    * Get the balance of tokens for a user.

--- a/src/token-client.ts
+++ b/src/token-client.ts
@@ -51,7 +51,7 @@ export default class TokenClient {
    *
    * @returns The token balance.
    */
-  public async getBalance(address: Address): Promise<Shard> {
-    return getTokenBalance(address, this.tokenAddress, this.tezos)
+  public async getBalance(address: Address, tokenContractStorage: any | undefined = undefined): Promise<Shard> {
+    return getTokenBalance(address, this.tokenAddress, this.tezos, tokenContractStorage)
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,8 @@ import {
   OperationResultTransaction,
 } from '@taquito/rpc'
 import _ from "lodash";
+import BigNumber from 'bignumber.js'
+import CONSTANTS from './constants'
 
 /**
  * Derive an oven address from the given operation.
@@ -26,4 +28,17 @@ export const deriveOvenAddress = async (operation: TransactionWalletOperation): 
   const ovenAddress = (ovenResult as OperationResultTransaction).originated_contracts![0]
 
   return ovenAddress
+}
+
+/**
+ * Convert an interest rate per period into an APY.
+ */
+export const interestRateToApy = async (interstRatePerPeriod: BigNumber): Promise<BigNumber> => {
+  const one = new BigNumber(1_000_000_000_000_000_000)
+  const initial = interstRatePerPeriod.plus(one)
+  let apy = one
+  for (let n = 0; n < CONSTANTS.COMPOUNDS_PER_YEAR; n++) {
+    apy = apy.times(initial).dividedBy(one)
+  }
+  return apy.minus(one)
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import Address from "./types/address"
-import { TransactionWalletOperation } from '@taquito/taquito'
+import { TezosToolkit, TransactionWalletOperation } from '@taquito/taquito'
 import {
   OperationContentsAndResult,
   OperationContentsAndResultTransaction,
@@ -48,4 +48,14 @@ export const interestRateToApy = async (interstRatePerPeriod: BigNumber): Promis
  */
 export const compoundingLinearApproximation = (initial: BigNumber, interestRatePerPeriod: BigNumber, numPeriods: number) => {
   return initial.times(CONSTANTS.PRECISION.plus(interestRatePerPeriod.times(numPeriods))).div(CONSTANTS.PRECISION)
+}
+
+/**
+ * Get a token balance from the default SmartPy implementation used by Kolibri.
+ */
+export const getTokenBalance = async (holder: Address, tokenContractAddress: Address, tezos: TezosToolkit): Promise<BigNumber> => {
+  const tokenContract = await tezos.contract.at(tokenContractAddress)
+  const tokenStorage: any = await tokenContract.storage()
+  const balance = await tokenStorage.balances.get(holder)
+  return balance === undefined ? new BigNumber(0) : balance.balance
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,7 +34,7 @@ export const deriveOvenAddress = async (operation: TransactionWalletOperation): 
  * Convert an interest rate per period into an APY.
  */
 export const interestRateToApy = async (interestRatePerPeriod: BigNumber): Promise<BigNumber> => {
-  const one = new BigNumber(1_000_000_000_000_000_000)
+  const one = new BigNumber(10).pow(18)
   const initial = interestRatePerPeriod.plus(one)
   let apy = one
   for (let n = 0; n < CONSTANTS.COMPOUNDS_PER_YEAR; n++) {
@@ -53,9 +53,13 @@ export const compoundingLinearApproximation = (initial: BigNumber, interestRateP
 /**
  * Get a token balance from the default SmartPy implementation used by Kolibri.
  */
-export const getTokenBalance = async (holder: Address, tokenContractAddress: Address, tezos: TezosToolkit): Promise<BigNumber> => {
-  const tokenContract = await tezos.contract.at(tokenContractAddress)
-  const tokenStorage: any = await tokenContract.storage()
-  const balance = await tokenStorage.balances.get(holder)
+export const getTokenBalance = async (
+  holder: Address,
+  tokenContractAddress: Address,
+  tezos: TezosToolkit,
+  tokenContractStorage: any | undefined = undefined
+): Promise<BigNumber> => {
+  const resolvedTokenStorage = tokenContractStorage ?? (await (await tezos.wallet.at(tokenContractAddress)).storage() as any)
+  const balance = await resolvedTokenStorage.balances.get(holder)
   return balance === undefined ? new BigNumber(0) : balance.balance
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,3 +42,10 @@ export const interestRateToApy = async (interstRatePerPeriod: BigNumber): Promis
   }
   return apy.minus(one)
 }
+
+/**
+ * Linearly approximate a compounding 
+ */
+export const compoundingLinearApproximation = (initial: BigNumber, interestRatePerPeriod: BigNumber, numPeriods: number) => {
+  return initial.times(CONSTANTS.PRECISION.plus(interestRatePerPeriod.times(numPeriods))).div(CONSTANTS.PRECISION)
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,9 +33,9 @@ export const deriveOvenAddress = async (operation: TransactionWalletOperation): 
 /**
  * Convert an interest rate per period into an APY.
  */
-export const interestRateToApy = async (interstRatePerPeriod: BigNumber): Promise<BigNumber> => {
+export const interestRateToApy = async (interestRatePerPeriod: BigNumber): Promise<BigNumber> => {
   const one = new BigNumber(1_000_000_000_000_000_000)
-  const initial = interstRatePerPeriod.plus(one)
+  const initial = interestRatePerPeriod.plus(one)
   let apy = one
   for (let n = 0; n < CONSTANTS.COMPOUNDS_PER_YEAR; n++) {
     apy = apy.times(initial).dividedBy(one)


### PR DESCRIPTION
New helpers to read data from chain:
- Get the interest rate as an APY
- Get the total pool size
- Get the total LP tokens
- Get the conversion rate of 1 LP token to kUSD
- Get an address's balance in LP tokens or kUSD

Lot's of modified code has overlap with `StableCoinClient` and `TokenClient`. Where possible, refactor implementations to `utils.ts`. 