### PR TITLE
Add better approximations of APY

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hover-labs/kolibri-js",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hover-labs/kolibri-js",
-      "version": "2.0.2",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@taquito/signer": "^10.2.1",
@@ -16,6 +16,7 @@
         "bignumber.js": "^9.0.1",
         "blakejs": "^1.1.1",
         "bs58check": "^2.1.2",
+        "decimal.js": "^10.3.1",
         "lodash": "^4.17.21"
       },
       "devDependencies": {
@@ -2353,10 +2354,9 @@
       }
     },
     "node_modules/decimal.js": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
-      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
-      "dev": true
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.0",
@@ -10749,10 +10749,9 @@
       "dev": true
     },
     "decimal.js": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
-      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
-      "dev": true
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
     },
     "decode-uri-component": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hover-labs/kolibri-js",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "SDK Code to Interact with Kolibri, a stablecoin built on Tezos",
   "main": "build/src/index.js",
   "files": [
@@ -48,6 +48,7 @@
     "bignumber.js": "^9.0.1",
     "blakejs": "^1.1.1",
     "bs58check": "^2.1.2",
+    "decimal.js": "^10.3.1",
     "lodash": "^4.17.21"
   }
 }

--- a/src/savings-pool-client.ts
+++ b/src/savings-pool-client.ts
@@ -5,6 +5,7 @@ import BigNumber from 'bignumber.js'
 import { compoundingLinearApproximation, getTokenBalance, interestRateToApy } from './utils'
 import CONSTANTS from './constants'
 import Address from './types/address'
+import Decimal from 'decimal.js'
 
 /**
  * Controls interaction with the Kolibri Savings Pool.
@@ -72,7 +73,7 @@ export default class SavingsPoolClient {
   /**
    * Get the interest rate of the pool.
    */
-  public async getInterestRateAPY(savingsPoolStorage: any | undefined = undefined): Promise<BigNumber> {
+  public async getInterestRateAPY(savingsPoolStorage: any | undefined = undefined): Promise<Decimal> {
     const resolvedSavingsPoolStorage = savingsPoolStorage ?? (await (await this.tezos.wallet.at(this.savingsPoolAddress)).storage() as any)
 
     const interestRate = resolvedSavingsPoolStorage.interestRate

--- a/src/stable-coin-client.ts
+++ b/src/stable-coin-client.ts
@@ -10,6 +10,7 @@ import BigNumber from 'bignumber.js'
 import axios, { AxiosResponse } from 'axios'
 import CONSTANTS from './constants'
 import { compoundingLinearApproximation, interestRateToApy } from './utils'
+import Decimal from 'decimal.js';
 
 /** The result of deploying an Oven. */
 export type OvenDeployResult = {
@@ -108,7 +109,7 @@ export default class StableCoinClient {
    *
    * @returns A number representing a percentage fee with 18 decimals of precision.
    */
-  public async getStabilityFeeApy(): Promise<Shard> {
+  public async getStabilityFeeApy(): Promise<Decimal> {
     const minterContract = await this.tezos.contract.at(this.minterAddress)
     const minterStorage: any = await minterContract.storage()
     const stabilityFee = await minterStorage.stabilityFee

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,7 @@ import {
 import _ from "lodash";
 import BigNumber from 'bignumber.js'
 import CONSTANTS from './constants'
+import Decimal from "decimal.js"
 
 /**
  * Derive an oven address from the given operation.
@@ -33,14 +34,12 @@ export const deriveOvenAddress = async (operation: TransactionWalletOperation): 
 /**
  * Convert an interest rate per period into an APY.
  */
-export const interestRateToApy = async (interestRatePerPeriod: BigNumber): Promise<BigNumber> => {
-  const one = new BigNumber(10).pow(18)
-  const initial = interestRatePerPeriod.plus(one)
-  let apy = one
-  for (let n = 0; n < CONSTANTS.COMPOUNDS_PER_YEAR; n++) {
-    apy = apy.times(initial).dividedBy(one)
-  }
-  return apy.minus(one)
+export const interestRateToApy = async (interestRatePerPeriod: BigNumber): Promise<Decimal> => {
+  const currentValueNoMantissa = new BigNumber(interestRatePerPeriod).dividedBy(new BigNumber(10).pow(18))
+  const currentValueDecimal = new Decimal(currentValueNoMantissa.toFixed(18)).times((60 * 24 * 365))
+  const E = new Decimal("2.7182818284590452353602874713526624977572470936999595749669676277240766303535475945713821785251664274")
+  const invertedLN = E.pow(currentValueDecimal)
+  return invertedLN.minus(1).times(100)
 }
 
 /**


### PR DESCRIPTION
Use a more performant implementation of `interestRateToApy` that returns a `Decimal` rather than `BigNumber`. This code is now consistent with the code on our front end. 

Since this is a breaking API change, prepare [bump the major version](https://semver.org/) of Kolibri-JS to 3.0.0