### PR TITLE
Add OvenClient ovenStorage parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hover-labs/kolibri-js",
-  "version": "3.0.8",
+  "version": "3.1.0",
   "description": "SDK Code to Interact with Kolibri, a stablecoin built on Tezos",
   "main": "build/src/index.js",
   "files": [


### PR DESCRIPTION
This PR adds in an `ovenStorage` parameter to most functions in the oven client, which allows for optimizing network calls when resolving multiple attributes about a single oven. 